### PR TITLE
Update so lang files nested inside the Locales get exported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.5",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
         "symfony/var-exporter": "^5.1"
     },

--- a/src/UFirst/LangImportExport/LangListService.php
+++ b/src/UFirst/LangImportExport/LangListService.php
@@ -42,7 +42,7 @@ class LangListService
     /**
      * Get all group translations from the application.
      *
-     * @return array
+     * @return array|Collection
      */
     public function allGroup($language)
     {
@@ -52,7 +52,11 @@ class LangListService
         }
         $groups = Collection::make($this->disk->allFiles($groupPath));
         return $groups->map(function ($group) {
-            return $group->getBasename('.php');
+            if (empty($group->getRelativePath())) {
+                return $group->getBasename('.php');
+            } else {
+                return $group->getRelativePath() . '/' . $group->getBasename('.php');
+            }
         });
     }
 }


### PR DESCRIPTION
I work on a project where we nest Lang files inside the locale folders.  When exporting I found these files threw exception,
```Failed to write *** with error: Array to string conversion```

Change is to support these nested files.

Resolves https://github.com/ufirstgroup/laravel-lang-import-export/issues/14

PHP version updated because of this message,
```Arbitrary expressions in 'empty' are only allowed since PHP 5.5 ```