### PR TITLE
Allow installing under Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.5",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0",
-        "symfony/var-exporter": "^5.1"
+        "symfony/var-exporter": "^6"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.5",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|^6.0|^7.0|^8.0|^9.0",
         "symfony/var-exporter": "^5.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,15 @@
     },
     "extra": {
         "component": "package",
-        "frameworks": ["Laravel 7"]
+        "frameworks": ["Laravel 7"],
+        "laravel": {
+            "providers": [
+                "UFirst\\LangImportExport\\LangImportExportServiceProvider"
+            ],
+            "aliases": {
+                "LangListService": "UFirst\\LangImportExport\\Facades\\LangListService"
+            }
+        }
     },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
This allows installations under Laravel 9, which was released a few days ago. This also automatically registers the service provider and facades through the [package discovery feature](https://laravel.com/docs/9.x/packages#package-discovery)

In addition, we could consider dropping support for older versions of the framework and set a minimum `php` requirement of `>=8.0` since Laravel 9 requires it as well.