### PR TITLE
FIX | import and export directory set to Storage/app directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ php artisan lang-export:csv -g navigation --output=/some/path/navigation-all-lan
 
 You can optionally pass the __-l__  (locale) and the __-g__  (group) as options. The group is the name of the langauge file without its extension. You may define options for your desired CSV format.
 
+**NB: Exported CSV file will saved inside the *Storage/app* directory**
+
 ### Import
 
 
@@ -105,6 +107,7 @@ php artisan lang-import:csv --merge=true /some/file.csv
 
 During import the locale is extracted from the first row of the CSV file. Translation groups are guessed from the translation keys e.g. __navigation.tips.next__ is imported to __navigation__ group
 
+  **NB: put the csv file inside *Storage/app* directory**
 
 ### Changelog
 

--- a/src/UFirst/LangImportExport/Console/ExportToCsvCommand.php
+++ b/src/UFirst/LangImportExport/Console/ExportToCsvCommand.php
@@ -96,8 +96,8 @@ class ExportToCsvCommand extends Command
 		}, $translations);
 		// Create output device and write CSV.
 		$output = $this->option('output');
-		if (empty($output) || !($out = fopen($output, 'w'))) {
-			$out = fopen('php://output', 'w');
+		if (empty($output) || !($out = fopen(app_path($output), 'w'))) {
+			$out = fopen(app_path('php://output'), 'w');
 		}
 		// Write CSV lintes
 		fputcsv($out, array_merge(["key"], $languages), $delimiter, $enclosure);

--- a/src/UFirst/LangImportExport/Console/ImportFromCsvCommand.php
+++ b/src/UFirst/LangImportExport/Console/ImportFromCsvCommand.php
@@ -69,7 +69,7 @@ class ImportFromCsvCommand extends Command
 		$merge = $this->option('merge');
 
 		// Create output device and write CSV.
-		if (($input_fp = fopen($file, 'r')) === FALSE) {
+		if (($input_fp = fopen(app_path($file), 'r')) === FALSE) {
 			$this->error('Can\'t open the input file!');
 		}
 


### PR DESCRIPTION
It's difficult to identify the location where the app reads/write the CSV file. I have set the read/write directory to the Storage/app directory. It's will help people to understand easily.