### PR TITLE
Support Laravel 9 location of language files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ navigation.tips.play,"Autoplay the slide show"
 Installation
 ------------
 
-### Laravel 9.* and above
+### Laravel 8.* and above
 
 ```bash
 composer require ufirst/lang-import-export:^8.1.0

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ navigation.tips.play,"Autoplay the slide show"
 Installation
 ------------
 
-### Laravel 8.* and above
+### Laravel 9.* and above
 
 ```bash
 composer require ufirst/lang-import-export:^8.1.0

--- a/src/UFirst/LangImportExport/Console/ImportFromCsvCommand.php
+++ b/src/UFirst/LangImportExport/Console/ImportFromCsvCommand.php
@@ -133,11 +133,14 @@ class ImportFromCsvCommand extends Command
 				}
 				$header = "<?php\n\nreturn ";
 				$language_dir = base_path("resources/lang/{$locale}");
+                if (! file_exists($language_dir) && file_exists(base_path("lang/{$locale}"))) {
+                    $language_dir = base_path("lang/{$locale}");
+                }
 				if (!is_writable($language_dir)) {
 					$this->error("Language directory $language_dir does not exist or is not writeable. Skipping");
 					continue;
 				}
-				$language_file = base_path("resources/lang/{$locale}/{$group}.php");
+				$language_file = $language_dir . "/{$group}.php";
 				if (!is_writable($language_file)) {
 					$this->info("Creating language file: $language_file");
 					touch($language_file);


### PR DESCRIPTION
Laravel 9 stores the language files no longer in `/resources/lang` but in `/lang`. This change is made to support both cases automatically, so no breaking changes.